### PR TITLE
gitmodules: fetch over https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs"]
 	path = docs
-	url = git@github.com:mattn/go-gtk.git
+	url = https://github.com/mattn/go-gtk


### PR DESCRIPTION
This way you don't have to have an SSH public key set up to clone the repo, which makes it a bit nicer to package and generally not surprise users with pubkey failures:

```
Permission denied (publickey).
fatal: Could not read from remote repository.
```
